### PR TITLE
fixes race condition

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,11 +4,24 @@ const assert = require('assert')
 module.exports = (pid, cb) => {
   assert(pid, 'pid required')
   const proc = run('osascript', [])
-  proc.end(`
-    tell application "System Events"
-      set frontmost of the first process whose unix id is ${pid} to true
-    end tell
-  `)
+  setImmediate(() => {
+    proc.end(`
+      tell application "System Events"
+        repeat with tries from 1 to 3
+          try
+            set frontmost of the first process whose unix id is ${pid} to true
+            exit repeat
+          on error errText number errNum
+          end try
+          delay 1
+        end repeat
+        if tries = 3 then
+          error errText number errNum
+        end if
+      end tell
+    `)
+  });
   proc.on('error', cb)
   proc.on('end', cb)
 }
+


### PR DESCRIPTION
I found that you have to wait a bit before you can set a `pid` to the foreground (presumably because the window has not been created yet, even though the pid `pid` might exist).

So, running the following code fails:

``` js
const launch = require('broser')

launch('osx', 'chrome', {
  uri: 'https://github.com'
}, (err, browser) => {
  if (err) throw err
  browser.on('error', console.error)
  setTimeout(() => {
    browser.kill();
  }, 2000);
}
```

with this error:

``` bash
/Users/eugeneware/Dropbox/work/tape-run/bro.js:6
  if (err) throw err
           ^

Error: non-zero exit code 1
  while running: osascript

  48:101: execution error: System Events got an error: Can’t get process 1 whose unix id = 83510. Invalid index. (-1719)

    at ChildProcess.<anonymous> (/Users/eugeneware/Dropbox/work/tape-run/node_modules/comandante/index.js:19:27)
    at emitTwo (events.js:111:20)
    at ChildProcess.emit (events.js:194:7)
    at maybeClose (internal/child_process.js:899:16)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:226:5)
```

This PR tries 3 times and waits a second between poll before failing.

My applescript skills are pretty non-existent, but this code does seem to work :-) 
